### PR TITLE
Fixes #1

### DIFF
--- a/src/HttpClientDiagnostics/HttpClientDiagnosticsHandler.cs
+++ b/src/HttpClientDiagnostics/HttpClientDiagnosticsHandler.cs
@@ -17,7 +17,6 @@ namespace HttpClientDiagnostics
 
         public HttpClientDiagnosticsHandler()
         {
-            InnerHandler = new HttpClientHandler();
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)


### PR DESCRIPTION
If you use `HttpClientFactory.Create(arrayOfHandlers)`, then each handler has to have an empty `InnerHandler`. However, you can't pass `null` to the first constructor, because the base constructor doesn't allow it.
